### PR TITLE
Add form helpers and flash message functionality

### DIFF
--- a/app/controllers/concerns/notice_i18n.rb
+++ b/app/controllers/concerns/notice_i18n.rb
@@ -1,0 +1,29 @@
+module NoticeI18n
+  extend ActiveSupport::Concern
+
+  private
+
+  def success_message(model = nil)
+    i18n_message(:success, model)
+  end
+
+  def failure_message(model = nil)
+    i18n_message(:failure, model)
+  end
+
+  def i18n_message(type, model = nil)
+    key = "#{controller_path.tr('/', '.')}.#{action_name}.#{type}"
+    default_key = "application.#{action_name}.#{type}"
+
+    options = {
+      default: I18n.t(default_key, default: "#{action_name.humanize} #{type}!")
+    }
+
+    if model.present?
+      options[:name] = model.model_name.human
+      options[:model] = model
+    end
+
+    I18n.t(key, **options)
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,20 @@
 module ApplicationHelper
+  def form_errors(instance, **locals)
+    locals[:instance] = instance
+    render partial: "application/form_errors", locals: locals
+  end
+
+  def flash_message(message, type: "secondary")
+    return nil if message.blank?
+
+    tag.div(
+      class: [ "flash-alert", "-#{type}" ].join(" "),
+      'data-controller': "alert",
+      'data-target': "alert",
+      'data-alert-close-btn-class': "close",
+      role: "alert"
+    ) do
+      message
+    end
+  end
 end

--- a/app/views/application/_flash_messages.html.erb
+++ b/app/views/application/_flash_messages.html.erb
@@ -1,0 +1,7 @@
+<% if notice %>
+  <%= flash_message(notice, type: "success") %>
+<% end %>
+
+<% if alert %>
+  <%= flash_message(alert, type: "danger") %>
+<% end %>

--- a/app/views/application/_form_errors.html.erb
+++ b/app/views/application/_form_errors.html.erb
@@ -1,0 +1,17 @@
+<% if instance.errors.any? %>
+  <div class="form-errors">
+    <h2 class="title">
+      <%= t(
+          ".title",
+          count: instance.errors.count,
+          name: (defined?(name) ? name : instance.class.model_name.human).downcase,
+      ) %>
+    </h2>
+
+    <ul class="list">
+      <% instance.errors.full_messages.each do |message| %>
+        <li class="item"><%= message %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -23,6 +23,9 @@
   </head>
 
   <body>
+    <div id="flash-messages">
+      <%= render "application/flash_messages" %>
+    </div>
     <%= yield %>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- Ported form helper utilities from summoncircle and joffre projects
- Added internationalized notice/alert system for better user feedback
- Implemented reusable form error display components

## Changes
- **Form Errors Helper**: Updated `form_errors` helper to render a partial with i18n support
- **Flash Message Helper**: Enhanced `flash_message` helper with alert controller integration
- **NoticeI18n Concern**: Added concern for internationalized success/failure messages
- **Partials**: Created `_form_errors` and `_flash_messages` partials
- **Layout Integration**: Added flash messages container to application layout

## Test plan
- [ ] Verify form errors display correctly when validation fails
- [ ] Test flash messages appear for notice and alert types
- [ ] Confirm i18n translations work for error messages
- [ ] Check alert controller dismissal functionality

🤖 Generated with [Claude Code](https://claude.ai/code)