### PR TITLE
Refactor GamesController to use message helpers

### DIFF
--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -1,4 +1,6 @@
 class GamesController < ApplicationController
+  include NoticeI18n
+
   before_action :set_game, only: %i[show edit update destroy]
 
   def index
@@ -16,8 +18,9 @@ class GamesController < ApplicationController
     @game = Current.user.games.build(game_params)
 
     if @game.save
-      redirect_to @game, notice: "Game was successfully created."
+      redirect_to @game, notice: success_message(@game)
     else
+      flash.now[:alert] = failure_message(@game)
       render :new, status: :unprocessable_entity
     end
   end
@@ -27,15 +30,16 @@ class GamesController < ApplicationController
 
   def update
     if @game.update(game_params)
-      redirect_to @game, notice: "Game was successfully updated."
+      redirect_to @game, notice: success_message(@game)
     else
+      flash.now[:alert] = failure_message(@game)
       render :edit, status: :unprocessable_entity
     end
   end
 
   def destroy
     @game.destroy!
-    redirect_to games_url, notice: "Game was successfully destroyed."
+    redirect_to games_url, notice: success_message(@game)
   end
 
   private

--- a/app/views/games/_form.html.erb
+++ b/app/views/games/_form.html.erb
@@ -1,14 +1,5 @@
 <%= form_with(model: game) do |form| %>
-  <% if game.errors.any? %>
-    <div id="error_explanation">
-      <h2><%= pluralize(game.errors.count, "error") %> prohibited this game from being saved:</h2>
-      <ul>
-        <% game.errors.full_messages.each do |message| %>
-          <li><%= message %></li>
-        <% end %>
-      </ul>
-    </div>
-  <% end %>
+  <%= form_errors(game) %>
 
   <div class="field">
     <%= form.label :name %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -29,3 +29,28 @@
 
 en:
   hello: "Hello world"
+
+  games:
+    create:
+      success: "%{name} was successfully created."
+      failure: "There was an error creating the %{name}."
+    update:
+      success: "%{name} was successfully updated."
+      failure: "There was an error updating the %{name}."
+    destroy:
+      success: "%{name} was successfully destroyed."
+
+  application:
+    create:
+      success: "%{name} was successfully created."
+      failure: "There was an error creating the %{name}."
+    update:
+      success: "%{name} was successfully updated."
+      failure: "There was an error updating the %{name}."
+    destroy:
+      success: "%{name} was successfully destroyed."
+
+  form_errors:
+    title:
+      one: "%{count} error prohibited this %{name} from being saved:"
+      other: "%{count} errors prohibited this %{name} from being saved:"


### PR DESCRIPTION
## Summary

This PR refactors the GamesController to use the existing but unused message helpers for consistent i18n-aware notifications and error handling.

### Changes:
- Include `NoticeI18n` concern in GamesController for i18n-aware messages
- Replace hardcoded success messages with `success_message` helper
- Add `failure_message` helper for create/update error cases  
- Replace inline error rendering in games form with `form_errors` helper
- Add i18n translations for games controller messages

### Benefits:
- Consistent message handling across the application
- Easy to maintain and update messages via i18n
- Reusable helpers reduce code duplication
- Better separation of concerns

All tests pass, linter shows no offenses, and security static analysis reports no warnings.

🤖 Generated with [Claude Code](https://claude.ai/code)