### PR TITLE
Add game play controller and state management

### DIFF
--- a/app/controllers/games/play_controller.rb
+++ b/app/controllers/games/play_controller.rb
@@ -1,0 +1,12 @@
+class Games::PlayController < ApplicationController
+  before_action :set_game
+
+  def show
+  end
+
+  private
+
+  def set_game
+    @game = Current.user.games.find(params[:game_id])
+  end
+end

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -6,6 +6,7 @@ class GamesController < ApplicationController
   end
 
   def show
+    redirect_to game_play_path(@game) if @game.playing?
   end
 
   def new
@@ -45,6 +46,6 @@ class GamesController < ApplicationController
   end
 
   def game_params
-    params.require(:game).permit(:name)
+    params.require(:game).permit(:name, :state)
   end
 end

--- a/app/helpers/games/play_helper.rb
+++ b/app/helpers/games/play_helper.rb
@@ -1,0 +1,2 @@
+module Games::PlayHelper
+end

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -4,4 +4,6 @@ class Game < ApplicationRecord
   has_many :characters, dependent: :destroy
 
   validates :name, presence: true
+
+  enum :state, { creating: 0, playing: 1 }, default: :creating
 end

--- a/app/views/games/index.html.erb
+++ b/app/views/games/index.html.erb
@@ -7,7 +7,6 @@
     <% @games.each do |game| %>
       <li>
         <%= link_to game.name, game %>
-        <%= link_to "Edit", edit_game_path(game) %>
         <%= button_to "Delete", game, method: :delete, data: { turbo_confirm: "Are you sure?" } %>
       </li>
     <% end %>

--- a/app/views/games/play/show.html.erb
+++ b/app/views/games/play/show.html.erb
@@ -1,0 +1,11 @@
+<div class="game-play">
+  <h1><%= @game.name %></h1>
+
+  <div class="game-area">
+    <p>Game is in progress...</p>
+  </div>
+
+  <p>
+    <%= link_to "Back to Games", games_path %>
+  </p>
+</div>

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -8,6 +8,15 @@
   </div>
 </div>
 
+<% if @game.creating? %>
+  <div class="game-start">
+    <p>When you're ready to start playing:</p>
+    <%= button_to "Start Game", game_path(@game), method: :patch,
+        params: { game: { state: "playing" } },
+        class: "btn btn-success" %>
+  </div>
+<% end %>
+
 <p>
   <%= link_to "Edit", edit_game_path(@game) %>
   <%= link_to "Back to Games", games_path %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
   resources :games do
     resources :areas
     resources :characters
+    resource :play, only: [ :show ], controller: "games/play"
   end
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 

--- a/db/migrate/20250702045741_add_state_to_games.rb
+++ b/db/migrate/20250702045741_add_state_to_games.rb
@@ -1,0 +1,5 @@
+class AddStateToGames < ActiveRecord::Migration[8.1]
+  def change
+    add_column :games, :state, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2025_07_02_000808) do
+ActiveRecord::Schema[8.1].define(version: 2025_07_02_045741) do
   create_table "areas", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.text "description"
@@ -34,6 +34,7 @@ ActiveRecord::Schema[8.1].define(version: 2025_07_02_000808) do
   create_table "games", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "name"
+    t.integer "state", default: 0, null: false
     t.datetime "updated_at", null: false
     t.integer "user_id", null: false
     t.index [ "user_id" ], name: "index_games_on_user_id"

--- a/test/controllers/games/play_controller_test.rb
+++ b/test/controllers/games/play_controller_test.rb
@@ -1,0 +1,26 @@
+require "test_helper"
+
+class Games::PlayControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = users(:one)
+    @game = games(:one)
+    sign_in_as(@user)
+  end
+
+  test "should get show" do
+    get game_play_url(@game)
+    assert_response :success
+  end
+
+  test "should require authentication" do
+    sign_out
+    get game_play_url(@game)
+    assert_redirected_to new_session_url
+  end
+
+  test "should not show other user's game" do
+    other_game = games(:two)
+    get game_play_url(other_game)
+    assert_response :not_found
+  end
+end

--- a/test/controllers/games_controller_test.rb
+++ b/test/controllers/games_controller_test.rb
@@ -1,7 +1,69 @@
 require "test_helper"
 
 class GamesControllerTest < ActionDispatch::IntegrationTest
-  # test "the truth" do
-  #   assert true
-  # end
+  setup do
+    @user = users(:one)
+    @game = games(:one)
+    sign_in_as(@user)
+  end
+
+  test "should get index" do
+    get games_url
+    assert_response :success
+  end
+
+  test "should get new" do
+    get new_game_url
+    assert_response :success
+  end
+
+  test "should create game" do
+    assert_difference("Game.count") do
+      post games_url, params: { game: { name: "New Game" } }
+    end
+
+    assert_redirected_to game_url(Game.last)
+  end
+
+  test "should show game when in creating state" do
+    @game.update!(state: :creating)
+    get game_url(@game)
+    assert_response :success
+  end
+
+  test "should redirect show to play controller when playing" do
+    @game.update!(state: :playing)
+    get game_url(@game)
+    assert_redirected_to game_play_url(@game)
+  end
+
+  test "should get edit" do
+    get edit_game_url(@game)
+    assert_response :success
+  end
+
+  test "should update game" do
+    patch game_url(@game), params: { game: { name: "Updated Name" } }
+    assert_redirected_to game_url(@game)
+  end
+
+  test "should destroy game" do
+    assert_difference("Game.count", -1) do
+      delete game_url(@game)
+    end
+
+    assert_redirected_to games_url
+  end
+
+  test "should require authentication" do
+    sign_out
+    get games_url
+    assert_redirected_to new_session_url
+  end
+
+  test "should not show other user's game" do
+    other_game = games(:two)
+    get game_url(other_game)
+    assert_response :not_found
+  end
 end

--- a/test/models/game_test.rb
+++ b/test/models/game_test.rb
@@ -1,7 +1,23 @@
 require "test_helper"
 
 class GameTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test "should have creating state by default" do
+    game = Game.new(name: "Test Game", user: users(:one))
+    assert_equal "creating", game.state
+  end
+
+  test "should be able to set playing state" do
+    game = Game.new(name: "Test Game", user: users(:one), state: :playing)
+    assert_equal "playing", game.state
+  end
+
+  test "should respond to state query methods" do
+    game = games(:one)
+    assert game.creating?
+    assert_not game.playing?
+
+    game.playing!
+    assert game.playing?
+    assert_not game.creating?
+  end
 end


### PR DESCRIPTION
## Summary
- Added game state management with creating/playing states
- Created a dedicated play controller for the gameplay area
- Implemented proper game flow from setup to playing

## Implementation Details
- Added `state` enum to Game model with values `creating` (default) and `playing`
- Created `Games::PlayController` to handle the gameplay area at `/games/:id/play`
- Games in "creating" state show the game management page with areas/characters
- Games in "playing" state redirect to the play area
- Added "Start Game" button on the game show page to transition states
- Removed edit link from games index for cleaner UI
- Added back button to play view for navigation

## Test plan
- [x] All existing tests pass
- [x] Added tests for game state enum functionality
- [x] Added tests for PlayController authentication and access control
- [x] Added tests for conditional redirect behavior
- [x] Linter passes with no offenses
- [x] Security analysis shows no warnings

🤖 Generated with [Claude Code](https://claude.ai/code)