### PR TITLE
Add auto-scroll functionality for message screens

### DIFF
--- a/app/javascript/controllers/auto_scroll_controller.js
+++ b/app/javascript/controllers/auto_scroll_controller.js
@@ -5,6 +5,7 @@ export default class extends Controller {
     this.scrollToBottom()
     this.setupScrollTracking()
     this.setupMutationObserver()
+    this.setupEventListeners()
   }
 
   disconnect() {
@@ -14,6 +15,7 @@ export default class extends Controller {
     if (this.scrollHandler) {
       this.element.removeEventListener('scroll', this.scrollHandler)
     }
+    this.removeEventListeners()
   }
 
   setupScrollTracking() {
@@ -49,6 +51,21 @@ export default class extends Controller {
 
   scrollToBottom() {
     this.element.scrollTop = this.element.scrollHeight
+  }
+
+  setupEventListeners() {
+    this.messageSentHandler = () => {
+      this.scrollToBottom()
+      this.wasAtBottom = true
+    }
+    
+    document.addEventListener('messageSent', this.messageSentHandler)
+  }
+
+  removeEventListeners() {
+    if (this.messageSentHandler) {
+      document.removeEventListener('messageSent', this.messageSentHandler)
+    }
   }
 
   childrenChanged() {

--- a/app/javascript/controllers/auto_scroll_controller.js
+++ b/app/javascript/controllers/auto_scroll_controller.js
@@ -3,6 +3,31 @@ import { Controller } from "@hotwired/stimulus"
 export default class extends Controller {
   connect() {
     this.scrollToBottom()
+    this.setupMutationObserver()
+  }
+
+  disconnect() {
+    if (this.observer) {
+      this.observer.disconnect()
+    }
+  }
+
+  setupMutationObserver() {
+    this.observer = new MutationObserver(() => {
+      if (this.isAtBottom()) {
+        this.scrollToBottom()
+      }
+    })
+
+    this.observer.observe(this.element, {
+      childList: true,
+      subtree: true
+    })
+  }
+
+  isAtBottom() {
+    const threshold = 50
+    return this.element.scrollHeight - this.element.scrollTop - this.element.clientHeight < threshold
   }
 
   scrollToBottom() {
@@ -10,6 +35,8 @@ export default class extends Controller {
   }
 
   childrenChanged() {
-    this.scrollToBottom()
+    if (this.isAtBottom()) {
+      this.scrollToBottom()
+    }
   }
 }

--- a/app/javascript/controllers/auto_scroll_controller.js
+++ b/app/javascript/controllers/auto_scroll_controller.js
@@ -3,6 +3,7 @@ import { Controller } from "@hotwired/stimulus"
 export default class extends Controller {
   connect() {
     this.scrollToBottom()
+    this.setupScrollTracking()
     this.setupMutationObserver()
   }
 
@@ -10,12 +11,28 @@ export default class extends Controller {
     if (this.observer) {
       this.observer.disconnect()
     }
+    if (this.scrollHandler) {
+      this.element.removeEventListener('scroll', this.scrollHandler)
+    }
+  }
+
+  setupScrollTracking() {
+    this.wasAtBottom = true
+    
+    this.scrollHandler = () => {
+      this.wasAtBottom = this.isAtBottom()
+    }
+    
+    this.element.addEventListener('scroll', this.scrollHandler)
   }
 
   setupMutationObserver() {
-    this.observer = new MutationObserver(() => {
-      if (this.isAtBottom()) {
-        this.scrollToBottom()
+    this.observer = new MutationObserver((mutations) => {
+      if (this.wasAtBottom) {
+        requestAnimationFrame(() => {
+          this.scrollToBottom()
+          this.wasAtBottom = true
+        })
       }
     })
 
@@ -35,7 +52,7 @@ export default class extends Controller {
   }
 
   childrenChanged() {
-    if (this.isAtBottom()) {
+    if (this.wasAtBottom) {
       this.scrollToBottom()
     }
   }

--- a/app/javascript/controllers/message_form_controller.js
+++ b/app/javascript/controllers/message_form_controller.js
@@ -7,7 +7,15 @@ export default class extends Controller {
       const form = this.element.closest('form')
       if (form) {
         form.requestSubmit()
+        this.scrollMessagesToBottom()
       }
+    }
+  }
+
+  scrollMessagesToBottom() {
+    const messagesContainer = document.querySelector('[data-controller="auto-scroll"]')
+    if (messagesContainer) {
+      messagesContainer.scrollTop = messagesContainer.scrollHeight
     }
   }
 }

--- a/app/javascript/controllers/message_form_controller.js
+++ b/app/javascript/controllers/message_form_controller.js
@@ -15,7 +15,7 @@ export default class extends Controller {
     if (event.key === "Enter" && !event.shiftKey) {
       event.preventDefault()
       this.element.requestSubmit()
-      this.scrollMessagesToBottom()
+      this.dispatch("messageSent")
     }
   }
 
@@ -26,10 +26,10 @@ export default class extends Controller {
     }
   }
 
-  scrollMessagesToBottom() {
-    const messagesContainer = document.querySelector('[data-controller="auto-scroll"]')
-    if (messagesContainer) {
-      messagesContainer.scrollTop = messagesContainer.scrollHeight
-    }
+  dispatch(eventName, detail = {}) {
+    this.element.dispatchEvent(new CustomEvent(eventName, { 
+      detail, 
+      bubbles: true 
+    }))
   }
 }

--- a/app/views/games/dm_messages/_form.html.erb
+++ b/app/views/games/dm_messages/_form.html.erb
@@ -1,6 +1,6 @@
 <%= form_with model: [@game, message], url: game_dm_messages_path(@game),
               local: false, id: "new_dm_message_form",
-              data: { controller: "message-form", action: "submit->message-form#scrollMessagesToBottom" } do |f| %>
+              data: { controller: "message-form" } do |f| %>
   <%= form_errors(message) %>
 
   <div class="input-group">

--- a/app/views/games/dm_messages/_form.html.erb
+++ b/app/views/games/dm_messages/_form.html.erb
@@ -1,13 +1,13 @@
-<%= form_with model: [@game, message], url: game_dm_messages_path(@game), 
+<%= form_with model: [@game, message], url: game_dm_messages_path(@game),
               local: false, id: "new_dm_message_form",
-              data: { controller: "message-form" } do |f| %>
+              data: { controller: "message-form", action: "submit->message-form#scrollMessagesToBottom" } do |f| %>
   <%= form_errors(message) %>
-  
+
   <div class="input-group">
-    <%= f.text_field :content, 
-                     class: "form-control", 
+    <%= f.text_field :content,
+                     class: "form-control",
                      placeholder: "Type your message...",
-                     data: { action: "keydown.enter->message-form#submit" } %>
+                     data: { action: "keydown.enter->message-form#submitOnEnter" } %>
     <%= f.submit "Send", class: "btn btn-primary" %>
   </div>
 <% end %>

--- a/app/views/games/messages/_form.html.erb
+++ b/app/views/games/messages/_form.html.erb
@@ -1,4 +1,5 @@
-<%= form_with(model: [game, message], id: "new_message_form", data: { turbo_frame: "_top" }) do |form| %>
+<%= form_with(model: [game, message], id: "new_message_form",
+              data: { turbo_frame: "_top", controller: "message-form", action: "submit->message-form#scrollMessagesToBottom" }) do |form| %>
   <%= form_errors(message) %>
 
   <div class="message-input-container">
@@ -7,7 +8,7 @@
         rows: 2,
         class: "message-input",
         autocomplete: "off",
-        data: { controller: "message-form", action: "keydown.enter->message-form#submitOnEnter" } %>
+        data: { action: "keydown.enter->message-form#submitOnEnter" } %>
     <%= form.submit "Send", class: "btn btn-primary" %>
   </div>
 <% end %>

--- a/app/views/games/messages/_form.html.erb
+++ b/app/views/games/messages/_form.html.erb
@@ -1,8 +1,7 @@
 <%= form_with(model: [game, message], id: "new_message_form",
               data: {
                 turbo_frame: "_top",
-                controller: "message-form",
-                action: "submit->message-form#scrollMessagesToBottom"
+                controller: "message-form"
               }) do |form| %>
   <%= form_errors(message) %>
   <% if defined?(character_id) && character_id.present? %>


### PR DESCRIPTION
## Summary
- Implemented sticky auto-scroll behavior for message/play screens
- Messages auto-scroll only when user is already at bottom of chat
- Sending messages automatically scrolls to bottom

## Implementation Details
- Enhanced existing `auto_scroll_controller.js` with proper scroll tracking
- Added continuous scroll position monitoring via scroll event listener
- MutationObserver detects new messages added via Turbo Streams
- 50px threshold for "at bottom" detection handles slight scroll variations
- Form submissions trigger immediate scroll to bottom
- Proper cleanup on controller disconnect

The auto-scroll maintains user position when scrolled up to read history, but keeps the chat following new messages when at bottom.

🤖 Generated with [Claude Code](https://claude.ai/code)