### PR TITLE
Refactor DM chat view to match play view layout

### DIFF
--- a/app/assets/stylesheets/game_play.css
+++ b/app/assets/stylesheets/game_play.css
@@ -19,7 +19,8 @@
 
 .game-info {
   display: flex;
-  gap: 2rem;
+  align-items: center;
+  gap: 1rem;
   font-size: 0.9rem;
   color: #666;
 }
@@ -172,11 +173,13 @@
   margin-left: 0.5rem;
 }
 
-.character-impersonation {
+.character-impersonation-wrapper {
+  border-bottom: 1px solid #ddd;
   background-color: #f8f9fa;
+}
+
+.character-impersonation {
   padding: 1rem;
-  border-radius: 0.5rem;
-  margin-bottom: 1rem;
 }
 
 .character-links {
@@ -187,4 +190,21 @@
 
 .character-link-item {
   margin-bottom: 0 !important;
+}
+
+/* Bootstrap utility classes for consistency */
+.ms-3 {
+  margin-left: 1rem;
+}
+
+.me-2 {
+  margin-right: 0.5rem;
+}
+
+.mb-2 {
+  margin-bottom: 0.5rem;
+}
+
+.small {
+  font-size: 0.875rem;
 }

--- a/app/assets/stylesheets/game_play.css
+++ b/app/assets/stylesheets/game_play.css
@@ -120,30 +120,11 @@
 }
 
 /* DM-specific styles */
-.dm-controls {
-  margin-top: 1rem;
-  padding-top: 1rem;
-  border-top: 1px solid #ddd;
-  display: flex;
-  gap: 2rem;
-  flex-wrap: wrap;
-}
-
-.dm-targeting {
-  flex: 1;
-  min-width: 300px;
-}
-
 .message-filter {
-  flex: 1;
-  min-width: 250px;
+  margin-top: 1rem;
 }
 
-.dm-controls .form-group {
-  margin-bottom: 0.75rem;
-}
-
-.dm-controls label {
+.message-filter label {
   display: block;
   margin-bottom: 0.25rem;
   font-size: 0.875rem;
@@ -151,7 +132,27 @@
   color: #555;
 }
 
-.dm-controls .form-select {
+.dm-form-controls {
+  display: flex;
+  gap: 1rem;
+  margin-bottom: 1rem;
+  flex-wrap: wrap;
+}
+
+.dm-form-controls .form-group {
+  flex: 1;
+  min-width: 150px;
+}
+
+.dm-form-controls label {
+  display: block;
+  margin-bottom: 0.25rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: #555;
+}
+
+.dm-form-controls .form-select {
   width: 100%;
   padding: 0.375rem 0.75rem;
   font-size: 0.875rem;

--- a/app/assets/stylesheets/game_play.css
+++ b/app/assets/stylesheets/game_play.css
@@ -117,3 +117,47 @@
   background: #f5f5f5;
   text-align: center;
 }
+
+/* DM-specific styles */
+.dm-controls {
+  margin-top: 1rem;
+  padding-top: 1rem;
+  border-top: 1px solid #ddd;
+  display: flex;
+  gap: 2rem;
+  flex-wrap: wrap;
+}
+
+.dm-targeting {
+  flex: 1;
+  min-width: 300px;
+}
+
+.message-filter {
+  flex: 1;
+  min-width: 250px;
+}
+
+.dm-controls .form-group {
+  margin-bottom: 0.75rem;
+}
+
+.dm-controls label {
+  display: block;
+  margin-bottom: 0.25rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: #555;
+}
+
+.dm-controls .form-select {
+  width: 100%;
+  padding: 0.375rem 0.75rem;
+  font-size: 0.875rem;
+  border: 1px solid #ced4da;
+  border-radius: 0.25rem;
+}
+
+.hidden {
+  display: none !important;
+}

--- a/app/controllers/games/dm_messages_controller.rb
+++ b/app/controllers/games/dm_messages_controller.rb
@@ -6,7 +6,20 @@ class Games::DmMessagesController < ApplicationController
     # DM messages have no character (they're from the system/DM)
     @message.character = nil
     @message.message_type = params[:message][:message_type] || "system"
-    @message.target_character_id = params[:message][:target_character_id]
+
+    # Handle different target types
+    target_type = params[:message][:target_type]
+    case target_type
+    when "character"
+      @message.target_character_id = params[:message][:target_character_id]
+      @message.area_id = nil
+    when "all"
+      @message.target_character_id = nil
+      @message.area_id = nil
+    when "area"
+      # area_id is already set from dm_message_params
+      @message.target_character_id = nil
+    end
 
     if @message.save
       respond_to do |format|

--- a/app/javascript/controllers/dm_message_form_controller.js
+++ b/app/javascript/controllers/dm_message_form_controller.js
@@ -1,10 +1,11 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static targets = ["targetSelect", "areaSelect", "characterSelect"]
+  static targets = ["targetSelect", "areaSelect", "characterSelect", "form"]
 
   connect() {
     this.toggleTargetSelect()
+    this.setupFormInterception()
   }
 
   toggleTargetSelect() {
@@ -29,6 +30,27 @@ export default class extends Controller {
     const select = selectElement.querySelector('select')
     if (select) {
       select.value = ''
+    }
+  }
+
+  setupFormInterception() {
+    if (this.hasFormTarget) {
+      const form = this.formTarget
+      form.addEventListener('submit', (e) => {
+        // Add the target selection values to the form
+        const targetType = this.targetSelectTarget.value
+        const formData = new FormData(form)
+        
+        formData.append('message[target_type]', targetType)
+        
+        if (targetType === 'area') {
+          const areaId = this.areaSelectTarget.querySelector('select').value
+          if (areaId) formData.append('message[area_id]', areaId)
+        } else if (targetType === 'character') {
+          const characterId = this.characterSelectTarget.querySelector('select').value
+          if (characterId) formData.append('message[target_character_id]', characterId)
+        }
+      })
     }
   }
 }

--- a/app/javascript/controllers/dm_message_form_controller.js
+++ b/app/javascript/controllers/dm_message_form_controller.js
@@ -1,11 +1,10 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static targets = ["targetSelect", "areaSelect", "characterSelect", "form", "impersonationSection", "toggleText"]
+  static targets = ["targetSelect", "areaSelect", "characterSelect", "impersonationSection", "toggleText"]
 
   connect() {
     this.toggleTargetSelect()
-    this.setupFormInterception()
   }
 
   toggleTargetSelect() {
@@ -30,27 +29,6 @@ export default class extends Controller {
     const select = selectElement.querySelector('select')
     if (select) {
       select.value = ''
-    }
-  }
-
-  setupFormInterception() {
-    if (this.hasFormTarget) {
-      const form = this.formTarget
-      form.addEventListener('submit', (e) => {
-        // Add the target selection values to the form
-        const targetType = this.targetSelectTarget.value
-        const formData = new FormData(form)
-        
-        formData.append('message[target_type]', targetType)
-        
-        if (targetType === 'area') {
-          const areaId = this.areaSelectTarget.querySelector('select').value
-          if (areaId) formData.append('message[area_id]', areaId)
-        } else if (targetType === 'character') {
-          const characterId = this.characterSelectTarget.querySelector('select').value
-          if (characterId) formData.append('message[target_character_id]', characterId)
-        }
-      })
     }
   }
 

--- a/app/javascript/controllers/dm_message_form_controller.js
+++ b/app/javascript/controllers/dm_message_form_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static targets = ["targetSelect", "areaSelect", "characterSelect", "form"]
+  static targets = ["targetSelect", "areaSelect", "characterSelect", "form", "impersonationSection", "toggleText"]
 
   connect() {
     this.toggleTargetSelect()
@@ -51,6 +51,17 @@ export default class extends Controller {
           if (characterId) formData.append('message[target_character_id]', characterId)
         }
       })
+    }
+  }
+
+  toggleImpersonation() {
+    if (this.hasImpersonationSectionTarget) {
+      this.impersonationSectionTarget.classList.toggle('hidden')
+      
+      if (this.hasToggleTextTarget) {
+        const isHidden = this.impersonationSectionTarget.classList.contains('hidden')
+        this.toggleTextTarget.textContent = isHidden ? 'Show Character Views' : 'Hide Character Views'
+      }
     }
   }
 }

--- a/app/views/games/dm/show.html.erb
+++ b/app/views/games/dm/show.html.erb
@@ -8,48 +8,15 @@
       </button>
     </div>
     
-    <div class="dm-controls">
-      <div class="dm-targeting">
-        <div class="form-group mb-2">
-          <label>Send to:</label>
-          <select name="message[target_type]" class="form-select" data-dm-message-form-target="targetSelect" data-action="change->dm-message-form#toggleTargetSelect">
-            <option value="area">Area</option>
-            <option value="character">Specific Character</option>
-            <option value="all">All Characters</option>
-          </select>
-        </div>
-
-        <div class="form-group mb-2" data-dm-message-form-target="areaSelect">
-          <select name="message[area_id]" class="form-select">
-            <option value="">Select an area</option>
-            <% @areas.each do |area| %>
-              <option value="<%= area.id %>"><%= area.name %></option>
-            <% end %>
-          </select>
-        </div>
-
-        <div class="form-group mb-2 hidden" data-dm-message-form-target="characterSelect">
-          <select name="message[target_character_id]" class="form-select">
-            <option value="">Select a character</option>
-            <% @characters.each do |character| %>
-              <option value="<%= character.id %>">
-                <%= character.name %><%= character.area ? " (#{character.area.name})" : " (No area)" %>
-              </option>
-            <% end %>
-          </select>
-        </div>
-      </div>
-
-      <div class="message-filter">
-        <label>Filter Messages:</label>
-        <select class="form-select" data-action="change->message-filter#filter">
-          <option value="all">All Messages</option>
-          <option value="private">Private Messages (No Area)</option>
-          <% @areas.each do |area| %>
-            <option value="area-<%= area.id %>"><%= area.name %></option>
-          <% end %>
-        </select>
-      </div>
+    <div class="message-filter">
+      <label>Filter Messages:</label>
+      <select class="form-select" data-action="change->message-filter#filter">
+        <option value="all">All Messages</option>
+        <option value="private">Private Messages (No Area)</option>
+        <% @areas.each do |area| %>
+          <option value="area-<%= area.id %>"><%= area.name %></option>
+        <% end %>
+      </select>
     </div>
   </header>
 

--- a/app/views/games/dm/show.html.erb
+++ b/app/views/games/dm/show.html.erb
@@ -3,28 +3,9 @@
     <h1><%= @game.name %> - Game Control</h1>
     <div class="game-info">
       <span class="text-muted">DM interface for controlling the game</span>
-    </div>
-
-    <div class="character-impersonation mb-3">
-      <h3>Character Views</h3>
-      <p class="text-muted">Open character views in new windows to act as them:</p>
-      <div class="character-links">
-        <% @characters.each do |character| %>
-          <div class="character-link-item mb-2">
-            <%= link_to game_play_path(@game, character_id: character.id), 
-                        target: "_blank", 
-                        class: "btn btn-sm #{character.is_player? ? 'btn-primary' : 'btn-secondary'}" do %>
-              Open as <%= character.name %>
-              <% if character.is_player? %>
-                <span class="badge badge-light">Player</span>
-              <% end %>
-              <% if character.area %>
-                <small class="text-muted">(<%= character.area.name %>)</small>
-              <% end %>
-            <% end %>
-          </div>
-        <% end %>
-      </div>
+      <button class="btn btn-sm btn-outline-secondary ms-3" data-action="click->dm-message-form#toggleImpersonation">
+        <span data-dm-message-form-target="toggleText">Show Character Views</span>
+      </button>
     </div>
     
     <div class="dm-controls">
@@ -71,6 +52,28 @@
       </div>
     </div>
   </header>
+
+  <div class="character-impersonation-wrapper hidden" data-dm-message-form-target="impersonationSection">
+    <div class="character-impersonation">
+      <h5>Character Views</h5>
+      <p class="text-muted small">Open character views in new windows to act as them:</p>
+      <div class="character-links">
+        <% @characters.each do |character| %>
+          <%= link_to game_play_path(@game, character_id: character.id), 
+                      target: "_blank", 
+                      class: "btn btn-sm #{character.is_player? ? 'btn-primary' : 'btn-secondary'} me-2 mb-2" do %>
+            <%= character.name %>
+            <% if character.is_player? %>
+              <span class="badge badge-light">Player</span>
+            <% end %>
+            <% if character.area %>
+              <small>(<%= character.area.name %>)</small>
+            <% end %>
+          <% end %>
+        <% end %>
+      </div>
+    </div>
+  </div>
 
   <%= turbo_stream_from "game_#{@game.id}_dm_messages" %>
 

--- a/app/views/games/dm/show.html.erb
+++ b/app/views/games/dm/show.html.erb
@@ -1,32 +1,12 @@
-<div class="game-play-container" data-controller="message-filter">
-  <div class="game-info">
-    <h1><%= @game.name %> - Game Control (Debug)</h1>
-    <p class="text-muted">
-      This is a debug interface for controlling the game. In the future, an AI agent will handle these DM functions.
-    </p>
-
-    <div class="message-filter mb-3">
-      <label>Filter Messages:</label>
-      <select class="form-select" data-action="change->message-filter#filter">
-        <option value="all">All Messages</option>
-        <option value="private">Private Messages (No Area)</option>
-        <% @areas.each do |area| %>
-          <option value="area-<%= area.id %>"><%= area.name %></option>
-        <% end %>
-      </select>
+<div class="game-play" data-controller="message-filter dm-message-form">
+  <header class="game-header">
+    <h1><%= @game.name %> - Game Control</h1>
+    <div class="game-info">
+      <span class="text-muted">DM interface for controlling the game</span>
     </div>
-  </div>
-
-  <%= turbo_stream_from "game_#{@game.id}_dm_messages" %>
-
-  <div class="chat-container">
-    <div id="messages" class="messages" data-controller="auto-scroll">
-      <%= render partial: 'games/messages/message', collection: @messages, locals: { is_dm_view: true } %>
-    </div>
-
-    <div class="message-form">
-      <%= form_with model: [@game, @message], url: game_dm_messages_path(@game), local: false,
-                    data: { controller: "dm-message-form message-form" } do |f| %>
+    
+    <div class="dm-controls">
+      <div class="dm-targeting">
         <div class="form-group mb-2">
           <label>Send to:</label>
           <select name="message[target_type]" class="form-select" data-dm-message-form-target="targetSelect" data-action="change->dm-message-form#toggleTargetSelect">
@@ -37,9 +17,12 @@
         </div>
 
         <div class="form-group mb-2" data-dm-message-form-target="areaSelect">
-          <%= f.select :area_id, options_from_collection_for_select(@areas, :id, :name),
-                       { include_blank: "Select an area" },
-                       class: "form-select" %>
+          <select name="message[area_id]" class="form-select">
+            <option value="">Select an area</option>
+            <% @areas.each do |area| %>
+              <option value="<%= area.id %>"><%= area.name %></option>
+            <% end %>
+          </select>
         </div>
 
         <div class="form-group mb-2 hidden" data-dm-message-form-target="characterSelect">
@@ -52,21 +35,37 @@
             <% end %>
           </select>
         </div>
+      </div>
 
-        <div class="form-group mb-2">
-          <label>Message Type:</label>
-          <%= f.select :message_type, options_for_select([["Chat", "chat"], ["System", "system"], ["Action", "action"]], "system"),
-                       {}, class: "form-select" %>
-        </div>
+      <div class="message-filter">
+        <label>Filter Messages:</label>
+        <select class="form-select" data-action="change->message-filter#filter">
+          <option value="all">All Messages</option>
+          <option value="private">Private Messages (No Area)</option>
+          <% @areas.each do |area| %>
+            <option value="area-<%= area.id %>"><%= area.name %></option>
+          <% end %>
+        </select>
+      </div>
+    </div>
+  </header>
 
-        <div class="input-group">
-          <%= f.text_field :content,
-                           class: "form-control",
-                           placeholder: "Type your message...",
-                           data: { controller: "message-form", action: "keydown.enter->message-form#submitOnEnter" } %>
-          <%= f.submit "Send", class: "btn btn-primary" %>
-        </div>
+  <%= turbo_stream_from "game_#{@game.id}_dm_messages" %>
+
+  <div class="chat-container">
+    <div class="messages-container" id="messages" data-controller="auto-scroll">
+      <% @messages.each do |message| %>
+        <%= render "games/messages/message", message: message, is_dm_view: true %>
       <% end %>
     </div>
+
+    <div class="message-form-container">
+      <%= render "games/dm_messages/form", game: @game, message: @message %>
+    </div>
   </div>
+
+  <footer class="game-footer">
+    <%= link_to "Back to Game", game_play_path(@game), class: "btn btn-primary" %>
+    <%= link_to "All Games", games_path, class: "btn btn-secondary" %>
+  </footer>
 </div>

--- a/app/views/games/dm_messages/_form.html.erb
+++ b/app/views/games/dm_messages/_form.html.erb
@@ -1,13 +1,21 @@
 <%= form_with model: [@game, message], url: game_dm_messages_path(@game), 
               local: false, id: "new_dm_message_form",
-              data: { controller: "message-form" } do |f| %>
+              data: { controller: "message-form", dm_message_form_target: "form" } do |f| %>
   <%= form_errors(message) %>
   
-  <div class="input-group">
-    <%= f.text_field :content, 
-                     class: "form-control", 
-                     placeholder: "Type your message...",
-                     data: { action: "keydown.enter->message-form#submit" } %>
+  <div class="form-group mb-2">
+    <label>Message Type:</label>
+    <%= f.select :message_type, options_for_select([["Chat", "chat"], ["System", "system"], ["Action", "action"]], "system"),
+                 {}, class: "form-select" %>
+  </div>
+  
+  <div class="message-input-container">
+    <%= f.text_area :content,
+        placeholder: "What do you want to say or do?",
+        rows: 2,
+        class: "message-input",
+        autocomplete: "off",
+        data: { controller: "message-form", action: "keydown.enter->message-form#submitOnEnter" } %>
     <%= f.submit "Send", class: "btn btn-primary" %>
   </div>
 <% end %>

--- a/app/views/games/dm_messages/_form.html.erb
+++ b/app/views/games/dm_messages/_form.html.erb
@@ -1,12 +1,40 @@
 <%= form_with model: [@game, message], url: game_dm_messages_path(@game),
               local: false, id: "new_dm_message_form",
-              data: { controller: "message-form", dm_message_form_target: "form" } do |f| %>
+              data: { controller: "message-form dm-message-form" } do |f| %>
   <%= form_errors(message) %>
   
-  <div class="form-group mb-2">
-    <label>Message Type:</label>
-    <%= f.select :message_type, options_for_select([["Chat", "chat"], ["System", "system"], ["Action", "action"]], "system"),
-                 {}, class: "form-select" %>
+  <div class="dm-form-controls">
+    <div class="form-group">
+      <label>Message Type:</label>
+      <%= f.select :message_type, options_for_select([["Chat", "chat"], ["System", "system"], ["Action", "action"]], "system"),
+                   {}, class: "form-select" %>
+    </div>
+
+    <div class="form-group">
+      <label>Send to:</label>
+      <select name="message[target_type]" class="form-select" data-dm-message-form-target="targetSelect" data-action="change->dm-message-form#toggleTargetSelect">
+        <option value="area">Area</option>
+        <option value="character">Specific Character</option>
+        <option value="all">All Characters</option>
+      </select>
+    </div>
+
+    <div class="form-group" data-dm-message-form-target="areaSelect">
+      <%= f.select :area_id, options_from_collection_for_select(@areas, :id, :name),
+                   { include_blank: "Select an area" },
+                   class: "form-select" %>
+    </div>
+
+    <div class="form-group hidden" data-dm-message-form-target="characterSelect">
+      <select name="message[target_character_id]" class="form-select">
+        <option value="">Select a character</option>
+        <% @characters.each do |character| %>
+          <option value="<%= character.id %>">
+            <%= character.name %><%= character.area ? " (#{character.area.name})" : " (No area)" %>
+          </option>
+        <% end %>
+      </select>
+    </div>
   </div>
   
   <div class="message-input-container">

--- a/test/controllers/games/play_controller_impersonation_test.rb
+++ b/test/controllers/games/play_controller_impersonation_test.rb
@@ -56,7 +56,7 @@ class Games::PlayControllerImpersonationTest < ActionDispatch::IntegrationTest
     assert_response :success
 
     @game.characters.each do |character|
-      assert_select "a[href='#{game_play_path(@game, character_id: character.id)}']", text: /Open as #{character.name}/
+      assert_select "a[href='#{game_play_path(@game, character_id: character.id)}']", text: /#{character.name}/
     end
   end
 end


### PR DESCRIPTION
## Summary
- Refactored DM chat view to use the same layout structure as the play view
- Moved send form to bottom with text area matching regular messages
- Made character impersonation a collapsible menu to reduce header clutter
- Moved target selection fields into the form for proper submission

## Changes
- **Unified layout**: Both DM and play views now use `.game-play` wrapper with consistent header/content/footer structure
- **Shared message partial**: Both views use the same `games/messages/_message` partial
- **Form improvements**: DM form now uses text area (not text field) and includes target selection inline
- **Collapsible impersonation**: Character view links are hidden by default with a toggle button
- **Proper form submission**: Target selection fields are now part of the form, ensuring values are submitted correctly

## Test plan
- [x] DM can send messages to specific areas
- [x] DM can send messages to specific characters
- [x] DM can send messages to all characters
- [x] Message filtering works correctly
- [x] Character impersonation links work
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)