### PR TITLE
Add DM messaging feature for players

### DIFF
--- a/app/assets/stylesheets/game_play.css
+++ b/app/assets/stylesheets/game_play.css
@@ -88,10 +88,40 @@
   font-size: 0.75rem;
 }
 
+.dm-whisper-indicator {
+  color: #6366f1;
+  font-weight: 500;
+}
+
 .message-form-container {
   border-top: 1px solid #ddd;
   padding: 1rem;
   background: #fafafa;
+}
+
+.message-controls {
+  margin-bottom: 0.75rem;
+}
+
+.message-controls .form-group {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.message-controls label {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: #555;
+  margin: 0;
+}
+
+.message-controls .form-select {
+  width: auto;
+  padding: 0.25rem 0.5rem;
+  font-size: 0.875rem;
+  border: 1px solid #ced4da;
+  border-radius: 0.25rem;
 }
 
 .message-input-container {

--- a/app/controllers/games/messages_controller.rb
+++ b/app/controllers/games/messages_controller.rb
@@ -5,8 +5,14 @@ class Games::MessagesController < ApplicationController
   def create
     @message = @game.messages.build(message_params)
     @message.character = @active_character
-    @message.area = @active_character.area
     @message.message_type = "chat"
+
+    if params[:message][:whisper_to_dm] == "true"
+      @message.area = nil
+      @message.is_dm_whisper = true
+    else
+      @message.area = @active_character.area
+    end
 
     if @message.save
       respond_to do |format|

--- a/app/javascript/controllers/player_message_form_controller.js
+++ b/app/javascript/controllers/player_message_form_controller.js
@@ -1,0 +1,8 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["targetSelect"]
+
+  connect() {
+  }
+}

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -17,7 +17,10 @@ class Message < ApplicationRecord
   private
 
   def create_witnesses
-    if area_id.present?
+    if is_dm_whisper
+      # Player whisper to DM: only the sender can see it
+      message_witnesses.create(character: character) if character
+    elsif area_id.present?
       # Area-based message: all characters in area can see it
       game.characters.where(area_id: area_id).find_each do |character|
         message_witnesses.create(character: character)

--- a/app/views/games/messages/_form.html.erb
+++ b/app/views/games/messages/_form.html.erb
@@ -1,12 +1,22 @@
 <%= form_with(model: [game, message], id: "new_message_form",
               data: {
                 turbo_frame: "_top",
-                controller: "message-form"
+                controller: "message-form player-message-form"
               }) do |form| %>
   <%= form_errors(message) %>
   <% if defined?(character_id) && character_id.present? %>
     <%= hidden_field_tag :character_id, character_id %>
   <% end %>
+
+  <div class="message-controls">
+    <div class="form-group">
+      <label for="message_target">Send to:</label>
+      <select name="message[whisper_to_dm]" id="message_target" class="form-select" data-player-message-form-target="targetSelect">
+        <option value="false">Room</option>
+        <option value="true">Whisper to DM</option>
+      </select>
+    </div>
+  </div>
 
   <div class="message-input-container">
     <%= form.text_area :content,

--- a/app/views/games/messages/_message.html.erb
+++ b/app/views/games/messages/_message.html.erb
@@ -22,8 +22,12 @@
   </div>
   <div class="message-location">
     <small>
-      <% if message.area %>
+      <% if message.is_dm_whisper %>
+        <span class="dm-whisper-indicator">🔒 Whispered to DM</span>
+      <% elsif message.area %>
         <%= message.area.name %>
+      <% elsif message.character.nil? && message.target_character_id.present? %>
+        <span class="dm-whisper-indicator">🔒 DM whispered to you</span>
       <% else %>
         Private (DM Channel)
       <% end %>

--- a/db/migrate/20250704072214_add_is_dm_whisper_to_messages.rb
+++ b/db/migrate/20250704072214_add_is_dm_whisper_to_messages.rb
@@ -1,0 +1,5 @@
+class AddIsDmWhisperToMessages < ActiveRecord::Migration[8.1]
+  def change
+    add_column :messages, :is_dm_whisper, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2025_07_03_025523) do
+ActiveRecord::Schema[8.1].define(version: 2025_07_04_072214) do
   create_table "areas", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.text "description"
@@ -18,7 +18,7 @@ ActiveRecord::Schema[8.1].define(version: 2025_07_03_025523) do
     t.string "name"
     t.json "properties"
     t.datetime "updated_at", null: false
-    t.index ["game_id"], name: "index_areas_on_game_id"
+    t.index [ "game_id" ], name: "index_areas_on_game_id"
   end
 
   create_table "characters", force: :cascade do |t|
@@ -30,9 +30,9 @@ ActiveRecord::Schema[8.1].define(version: 2025_07_03_025523) do
     t.string "name"
     t.json "properties"
     t.datetime "updated_at", null: false
-    t.index ["area_id"], name: "index_characters_on_area_id"
-    t.index ["game_id", "is_player"], name: "index_characters_on_game_id_and_is_player", unique: true, where: "is_player = true"
-    t.index ["game_id"], name: "index_characters_on_game_id"
+    t.index [ "area_id" ], name: "index_characters_on_area_id"
+    t.index [ "game_id", "is_player" ], name: "index_characters_on_game_id_and_is_player", unique: true, where: "is_player = true"
+    t.index [ "game_id" ], name: "index_characters_on_game_id"
   end
 
   create_table "games", force: :cascade do |t|
@@ -41,7 +41,7 @@ ActiveRecord::Schema[8.1].define(version: 2025_07_03_025523) do
     t.integer "state", default: 0, null: false
     t.datetime "updated_at", null: false
     t.integer "user_id", null: false
-    t.index ["user_id"], name: "index_games_on_user_id"
+    t.index [ "user_id" ], name: "index_games_on_user_id"
   end
 
   create_table "message_witnesses", force: :cascade do |t|
@@ -49,9 +49,9 @@ ActiveRecord::Schema[8.1].define(version: 2025_07_03_025523) do
     t.datetime "created_at", null: false
     t.integer "message_id", null: false
     t.datetime "updated_at", null: false
-    t.index ["character_id"], name: "index_message_witnesses_on_character_id"
-    t.index ["message_id", "character_id"], name: "index_message_witnesses_on_message_id_and_character_id", unique: true
-    t.index ["message_id"], name: "index_message_witnesses_on_message_id"
+    t.index [ "character_id" ], name: "index_message_witnesses_on_character_id"
+    t.index [ "message_id", "character_id" ], name: "index_message_witnesses_on_message_id_and_character_id", unique: true
+    t.index [ "message_id" ], name: "index_message_witnesses_on_message_id"
   end
 
   create_table "messages", force: :cascade do |t|
@@ -60,11 +60,12 @@ ActiveRecord::Schema[8.1].define(version: 2025_07_03_025523) do
     t.text "content"
     t.datetime "created_at", null: false
     t.integer "game_id", null: false
+    t.boolean "is_dm_whisper", default: false, null: false
     t.string "message_type"
     t.datetime "updated_at", null: false
-    t.index ["area_id"], name: "index_messages_on_area_id"
-    t.index ["character_id"], name: "index_messages_on_character_id"
-    t.index ["game_id"], name: "index_messages_on_game_id"
+    t.index [ "area_id" ], name: "index_messages_on_area_id"
+    t.index [ "character_id" ], name: "index_messages_on_character_id"
+    t.index [ "game_id" ], name: "index_messages_on_game_id"
   end
 
   create_table "sessions", force: :cascade do |t|
@@ -73,7 +74,7 @@ ActiveRecord::Schema[8.1].define(version: 2025_07_03_025523) do
     t.datetime "updated_at", null: false
     t.string "user_agent"
     t.integer "user_id", null: false
-    t.index ["user_id"], name: "index_sessions_on_user_id"
+    t.index [ "user_id" ], name: "index_sessions_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -81,7 +82,7 @@ ActiveRecord::Schema[8.1].define(version: 2025_07_03_025523) do
     t.string "email_address", null: false
     t.string "password_digest", null: false
     t.datetime "updated_at", null: false
-    t.index ["email_address"], name: "index_users_on_email_address", unique: true
+    t.index [ "email_address" ], name: "index_users_on_email_address", unique: true
   end
 
   add_foreign_key "areas", "games"


### PR DESCRIPTION
## Summary
- Added dropdown selector in player message form to choose between "Room" or "Whisper to DM"
- Players can now send private messages directly to the DM
- Messages are properly secured with witness logic ensuring only sender and DM can see whispers

## Implementation Details
- Added `is_dm_whisper` boolean field to messages table
- Updated MessagesController to handle whisper_to_dm parameter
- Modified message witness creation logic for DM whispers
- Added visual indicators (🔒) to distinguish DM whispers
- Added CSS styling for new message controls

## Test plan
- [x] Run linter - all passing
- [x] Run tests - all passing
- [x] Run security analysis - no issues
- [ ] Test sending regular room messages as a player
- [ ] Test sending whispers to DM as a player
- [ ] Verify DM can see all whispers in DM view
- [ ] Verify other players cannot see whispers
- [ ] Test visual indicators appear correctly

🤖 Generated with [Claude Code](https://claude.ai/code)