### PR TITLE
Add db/schema.rb to rubocop exclude list

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,3 +10,4 @@ inherit_gem: { rubocop-rails-omakase: rubocop.yml }
 AllCops:
   Exclude:
     - 'db/*_schema.rb'
+    - 'db/schema.rb'


### PR DESCRIPTION
## Summary
- Add `db/schema.rb` to the rubocop exclude list in `.rubocop.yml`
- This ensures all database schema files are properly ignored by rubocop, including the main `schema.rb` file which wasn't covered by the existing `db/*_schema.rb` pattern